### PR TITLE
Properly name interfaces

### DIFF
--- a/client/components/Article.svelte
+++ b/client/components/Article.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import type { ArticleInterface } from "./types";
+  import type { IArticle } from "./types";
 
   export let slug: string;
-  export let article: ArticleInterface | null = null;
+  export let article: IArticle | null = null;
 
   onMount(async () => {
     const res = await fetch(`/api/article/${slug}`, {

--- a/client/components/ArticleList.svelte
+++ b/client/components/ArticleList.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { Link } from "svelte-routing";
-  import type { ArticleInterface } from "./types";
+  import type { IArticle } from "./types";
 
-  export let articles: ArticleInterface[];
+  export let articles: IArticle[];
   export let articleCount: number | null = null;
 
   onMount(async () => {

--- a/client/components/index.ts
+++ b/client/components/index.ts
@@ -6,7 +6,7 @@ export { default as SpecialHeading } from "./SpecialHeading.svelte";
 
 export { HeadingType } from "./types";
 export type {
-  ArticleInterface,
-  ArticleMetadataInterface,
-  NotFoundErrorInterface,
+  IArticle,
+  IArticleMetadata,
+  INotFoundError,
 } from "./types";

--- a/client/components/types.ts
+++ b/client/components/types.ts
@@ -1,4 +1,4 @@
-export interface ArticleMetadataInterface {
+export interface IArticleMetadata {
   title: string,
   excerpt: string,
   slug: string,
@@ -6,16 +6,16 @@ export interface ArticleMetadataInterface {
   tags: string[],
 }
 
-export interface NotFoundErrorInterface {
+export interface INotFoundError {
   code: number,
   description: string,
   reason: string,
 }
 
-export interface ArticleInterface {
-  metadata?: ArticleMetadataInterface,
+export interface IArticle {
+  metadata?: IArticleMetadata,
   html?: string,
-  error?: NotFoundErrorInterface,
+  error?: INotFoundError,
 }
 
 export const enum HeadingType {

--- a/client/pages/Article.svelte
+++ b/client/pages/Article.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Article } from "../components";
-  import type { ArticleInterface } from "../components";
+  import type { IArticle } from "../components";
   import NotFound from "./NotFound.svelte";
 
   export let slug: string;
-  export let article: ArticleInterface | null = null;
+  export let article: IArticle | null = null;
 
   $: component = (article && article?.error) ? NotFound : Article;
 </script>

--- a/client/pages/Articles.svelte
+++ b/client/pages/Articles.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { ArticleList, SpecialHeading } from "../components";
-  import type { ArticleInterface } from "../components"
+  import type { IArticle } from "../components"
 
-  export let articles: ArticleInterface[] | null = null;
+  export let articles: IArticle[] | null = null;
 </script>
 
 <svelte:head>

--- a/client/pages/Home.svelte
+++ b/client/pages/Home.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { ArticleList, SpecialHeading } from "../components";
-  import type { ArticleInterface } from "../components";
+  import type { IArticle } from "../components";
 
-  export let articles: ArticleInterface[] | null = null;
+  export let articles: IArticle[] | null = null;
 </script>
 
 <svelte:head>


### PR DESCRIPTION
`ObjectInterface` is too verbose. Use `IInterface` instead